### PR TITLE
Fixes absolute path reference that won't work for many users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   ],
   "authors":     [
     {
-      "name":  "Yaroslav Mokhurenko",
-      "email": "yaroslavm@softwareplanet.com"
+      "name":  "DreamFactory Developers",
+      "email": "code@dreamfactory.com"
     }
   ],
   "support":     {

--- a/src/Models/ExampleConfig.php
+++ b/src/Models/ExampleConfig.php
@@ -48,7 +48,6 @@ class ExampleConfig extends BaseServiceConfigModel
             case 'label':
                 $schema['label'] = 'Simple label';
                 $schema['type'] = 'text';
-                $schema['required'] = false;
                 $schema['description'] = 'This is just a simple label';
                 break;
 
@@ -61,6 +60,7 @@ class ExampleConfig extends BaseServiceConfigModel
             case 'is_example':
                 $schema['label'] = 'Is this an example?';
                 $schema['type'] = 'boolean';
+                $schema['required'] = false;
                 $schema['description'] =
                     'It must be an example';
                 break;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         // add routes
         /** @noinspection PhpUndefinedMethodInspection */
         if (!$this->app->routesAreCached()) {
-            include app_path('vendor/dreamfactory/df-skeleton/routes/routes.php');
+            include __DIR__ . '/../routes/routes.php';
         }
 
         $this->addMiddleware();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         // add routes
         /** @noinspection PhpUndefinedMethodInspection */
         if (!$this->app->routesAreCached()) {
-            include '/opt/dreamfactory/vendor/dreamfactory/df-skeleton/routes/routes.php';
+            include app_path('vendor/dreamfactory/df-skeleton/routes/routes.php');
         }
 
         $this->addMiddleware();


### PR DESCRIPTION
In `ServiceProvider.php` there was a reference to `/opt/dreamfactory...`. This path won't exist for many users, so I replaced it with a reference to [app_path()](https://laravel.com/docs/master/helpers#method-app-path).